### PR TITLE
Show loading state while fetching a random quote

### DIFF
--- a/apps/web/components/Header.tsx
+++ b/apps/web/components/Header.tsx
@@ -1,24 +1,29 @@
 "use client";
 import RandomBtn from "@repo/ui/src/RandomBtn";
 import { usePathname, useRouter } from "next/navigation";
+import { useTransition } from "react";
 import ThemeToggle from "./ThemeToggle";
 
 const Header = () => {
   const router = useRouter();
   const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+
   const handleRandomQuote = () => {
-    if (pathname !== "/") {
-      router.push("/");
-      return;
-    }
-    router.refresh();
+    startTransition(() => {
+      if (pathname !== "/") {
+        router.push("/");
+        return;
+      }
+      router.refresh();
+    });
   };
 
   return (
     <header>
       <nav className="flex items-center justify-end gap-3 pt-8">
         <ThemeToggle />
-        <RandomBtn onClick={handleRandomQuote} />
+        <RandomBtn isLoading={isPending} onClick={handleRandomQuote} />
       </nav>
     </header>
   );

--- a/packages/ui/src/RandomBtn.tsx
+++ b/packages/ui/src/RandomBtn.tsx
@@ -1,36 +1,47 @@
 "use client";
 
 type RandomBtnProps = {
+  isLoading?: boolean;
   onClick?: () => void;
 };
 
-const RefreshIcon = () => (
-  <svg
+const RefreshIcon = ({ isLoading = false }: { isLoading?: boolean }) => (
+  <span
     aria-hidden="true"
-    className="h-4 w-4 transition duration-200 group-hover:rotate-180"
-    fill="none"
-    viewBox="0 0 24 24"
-    stroke="currentColor"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    strokeWidth="2"
+    className={`h-4 w-4 ${
+      isLoading
+        ? "animate-spin"
+        : "transition duration-200 group-hover:rotate-180"
+    }`}
   >
-    <path d="M21 12a9 9 0 0 1-15.2 6.5" />
-    <path d="M3 12A9 9 0 0 1 18.2 5.5" />
-    <path d="M3 20v-6h6" />
-    <path d="M21 4v6h-6" />
-  </svg>
+    <svg
+      className="h-full w-full"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+    >
+      <path d="M21 12a9 9 0 0 1-15.2 6.5" />
+      <path d="M3 12A9 9 0 0 1 18.2 5.5" />
+      <path d="M3 20v-6h6" />
+      <path d="M21 4v6h-6" />
+    </svg>
+  </span>
 );
 
-const RandomBtn = ({ onClick }: RandomBtnProps) => {
+const RandomBtn = ({ isLoading = false, onClick }: RandomBtnProps) => {
   return (
     <button
       type="button"
+      aria-busy={isLoading}
       onClick={onClick}
+      disabled={isLoading}
       className="group flex h-10 items-center gap-2 rounded-full px-3 text-base text-[#4F4F4F] transition hover:bg-[#F7DF94]/25 hover:text-[#333333] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#F7DF94] dark:text-[#F2F2F2] dark:hover:bg-[#F7DF94]/20 dark:hover:text-white lg:text-base"
     >
       random
-      <RefreshIcon />
+      <RefreshIcon isLoading={isLoading} />
     </button>
   );
 };


### PR DESCRIPTION
## Summary
- Wrap the random quote navigation in `useTransition` so the header can reflect pending state
- Disable the random button while the transition is active
- Swap the refresh icon animation to a spinner during loading

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Random button now displays a loading state with visual feedback during operations.
  * The refresh icon animates while an action is processing.
  * Button is temporarily disabled during loading to prevent duplicate requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->