### PR TITLE
Add CI, fix typecheck, refresh docs, and normalize formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +24,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint, typecheck, test & build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  e2e:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: apps/web
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,22 @@
+# Dependencies & lockfiles
+node_modules/
+package-lock.json
+
+# Build outputs
+.next/
+out/
+build/
+dist/
+coverage/
+
+# Test & tooling artifacts
+playwright-report/
+test-results/
+.turbo/
+
+# Generated files
+next-env.d.ts
+**/public/service-worker.js
+**/public/workbox-*.js
+**/public/sw.js
+**/public/fallback-*.js

--- a/CODE_FLOW.md
+++ b/CODE_FLOW.md
@@ -6,147 +6,137 @@ flowchart TD
         U1([Visit /])
         U2([Click AuthorBtn])
         U3([Scroll Down])
-        U4([Click Header/RandomBtn])
+        U4([Click RandomBtn])
+        U5([Toggle theme])
     end
 
     subgraph NEXT["Next.js App Router · apps/web/app/"]
         subgraph LAYOUT["layout.tsx · Root Layout"]
-            L1[Apply fonts\nRaleway + Montserrat]
-            L2[Render Header + Footer]
+            L1[Metadata + PWA + viewport]
+            L2[Render Header + main + Footer]
         end
 
-        subgraph HOME["page.tsx · Home Route"]
-            H1[fetchRandomQuote\nSERVER ACTION]
-            H2[GET /v1/quote/random]
+        subgraph HOME["page.tsx · Home Route · Server"]
+            H1[fetchRandomQuote]
         end
 
-        subgraph AUTHOR["[authorId]/page.tsx · Author Route"]
-            A1[fetchAuthorQuotes\nSERVER ACTION]
-            A2["GET /v1/quote/{author}\n?limit=20&offset=0"]
-            A3[generateMetadata]
+        subgraph AUTHOR["[authorId]/page.tsx · Author Route · Server"]
+            A1[fetchAuthorQuotes author, 0]
+            A3[generateMetadata → title]
         end
 
-        subgraph DATA["lib/data.ts · Data Layer"]
-            D1[fetchRandomQuote\nunstable_noStore]
-            D2[fetchAuthorQuotes\nunstable_noStore]
+        subgraph ROUTE["api/quotes/[author]/route.ts · Route Handler"]
+            R1[GET ?offset=N]
+            R2[fetchAuthorQuotes author, offset]
+            R3[Cache-Control s-maxage=300, swr=86400]
+        end
+
+        subgraph DATA["lib/data.ts · Server-side Data Layer"]
+            D1[fetchRandomQuote\ncache: no-store · 120ms timeout]
+            D2[fetchAuthorQuotes\nrevalidate: 300 · 650ms timeout]
+            D3[FALLBACK_QUOTES\nlocal resilience on error]
+        end
+
+        subgraph LOADING["loading.tsx · Suspense fallbacks"]
+            LD1[Home: QuoteSkeleton + AuthorBtnSkeleton]
+            LD2[Author: 5× QuoteSkeleton]
+        end
+    end
+
+    subgraph WEBCOMP["App Components · apps/web/components/"]
+        subgraph HEADER_C["Header.tsx · Client"]
+            HC1[useTransition + useRouter + usePathname]
+            HC2[not on / → router.push / else router.refresh]
+        end
+        subgraph THEME_C["ThemeToggle.tsx · Client"]
+            TC1[localStorage quoto-theme]
+            TC2[toggle .dark on html]
         end
     end
 
     subgraph UI["Shared UI Library · packages/ui/src/"]
-        subgraph HEADER_C["Header.tsx · Client Component"]
-            HC1[useRouter\nusePathname]
-            HC2["router.push / router.refresh()"]
+        QUOTE_C["Quote.tsx · details disclosure\nsummary = text, body = author/genre"]
+        AUTHOR_BTN["AuthorBtn.tsx · anchor → /author"]
+        RANDOM_BTN["RandomBtn.tsx · isLoading spinner"]
+        subgraph LOAD_MORE["LoadMore.tsx · Client"]
+            LM1[IntersectionObserver sentinel\nrootMargin 360px]
+            LM2[fetch /api/quotes/author?offset]
+            LM3[append quotes to state]
+            LM4[show QuoteSkeleton while loading]
+            LM5[exhausted → MoveToTop]
         end
-
-        subgraph QUOTE_C["Quote.tsx · Client Component"]
-            Q1[MotionDiv wrapper]
-            Q2[Display quote text\n+ metadata]
-        end
-
-        subgraph AUTHOR_BTN["AuthorBtn.tsx · Client Component"]
-            AB1[MotionDiv wrapper]
-            AB2[Link → /authorId]
-        end
-
-        subgraph LOAD_MORE["LoadMore.tsx · Client Component"]
-            LM1[useInView\nIntersection Observer]
-            LM2[fetchAuthorQuotes\noffset += 20]
-            LM3[Append new quotes\nto state]
-            LM4[Show QuoteSkeleton\nwhile loading]
-        end
-
-        subgraph MOVE_TOP["MoveToTop.tsx · Client"]
-            MT1[Show when\nno more quotes]
-            MT2[Scroll to top]
-        end
-
-        subgraph MOTION["MotionDiv.tsx · Client"]
-            MV1[framer-motion\nmotion.div]
-        end
-
-        subgraph ANIMATE["utils/animate.tsx"]
-            AN1[container variants\nstaggerChildren]
-            AN2[item variants\nslide-in + fade]
-        end
-
-        subgraph SKELETONS["skeletons/"]
-            SK1[QuoteSkeleton]
-            SK2[AuthorBtnSkeleton]
-        end
+        MOVE_TOP["MoveToTop.tsx · anchor → #top"]
+        SKELETONS["skeletons/ · QuoteSkeleton, AuthorBtnSkeleton"]
+        FOOTER["Footer.tsx · credit link"]
     end
 
     subgraph API["External API · api-quoto.onrender.com"]
         API1[GET /v1/quote/random]
-        API2["GET /v1/quote/{author}\n?limit&offset"]
+        API2["GET /v1/quote/{author}?limit&offset"]
     end
 
     %% Entry flow
-    U1 --> LAYOUT
-    LAYOUT --> HOME
-    HOME --> H1
-    H1 --> D1
-    D1 --> API1
-    API1 --> H2
-    H2 --> QUOTE_C
-    H2 --> AUTHOR_BTN
+    U1 --> LAYOUT --> HOME --> H1 --> D1 --> API1
+    D1 -. on error/timeout .-> D3
+    H1 --> QUOTE_C
+    H1 --> AUTHOR_BTN
+    HOME -. Suspense .-> LD1
 
     %% Author navigation
-    U2 --> AUTHOR_BTN
-    AB2 --> AUTHOR
-    AUTHOR --> A1
-    A1 --> D2
-    D2 --> API2
-    API2 --> A2
-    A2 --> QUOTE_C
-    A2 --> LOAD_MORE
+    U2 --> AUTHOR_BTN --> AUTHOR --> A1 --> D2 --> API2
+    D2 -. on error/timeout .-> D3
+    A1 --> QUOTE_C
+    A1 --> LOAD_MORE
+    AUTHOR -. Suspense .-> LD2
 
     %% Infinite scroll
-    U3 --> LM1
-    LM1 -- "in view" --> LM2
-    LM2 --> D2
-    LM4 --> SK1
-    LM2 --> LM3
-    LM3 --> QUOTE_C
-    LM3 -- "exhausted" --> MOVE_TOP
+    U3 --> LM1 -- in view --> LM2 --> R1 --> R2 --> D2
+    LM4 --> SKELETONS
+    LM2 --> LM3 --> QUOTE_C
+    LM3 -- no more --> LM5 --> MOVE_TOP
 
-    %% Header navigation
-    U4 --> HEADER_C
-    HC1 --> HC2
-    HC2 -- "already on /" --> HC2
-    HC2 -- "navigate" --> HOME
-
-    %% Shared animation
-    QUOTE_C --> MV1
-    AUTHOR_BTN --> MV1
-    MV1 --> AN1
-    MV1 --> AN2
-
-    %% Loading skeletons shown during fetch
-    HOME -. "Suspense" .-> SK2
-    AUTHOR -. "Suspense" .-> SK1
+    %% Header + theme
+    LAYOUT --> HEADER_C
+    HEADER_C --> RANDOM_BTN
+    HEADER_C --> THEME_C
+    U4 --> HC1 --> HC2 --> HOME
+    U5 --> TC1 --> TC2
 ```
 
 ## Module Responsibilities
 
-| Module | Type | Responsibility |
-|--------|------|---------------|
-| `app/layout.tsx` | Server | Root layout: fonts, Header, Footer, metadata, PWA |
-| `app/page.tsx` | Server | Home route — fetches and displays a random quote |
-| `app/[authorId]/page.tsx` | Server | Author route — fetches and displays paginated author quotes |
-| `app/lib/data.ts` | Server Action | All API calls to external quote API (no caching) |
-| `components/Header.tsx` | Client | Navigation bar; refresh triggers new random quote |
-| `packages/ui/Quote.tsx` | Client | Animated quote card display |
-| `packages/ui/AuthorBtn.tsx` | Client | Animated author link button |
-| `packages/ui/LoadMore.tsx` | Client | Infinite scroll via Intersection Observer + pagination |
-| `packages/ui/MoveToTop.tsx` | Client | Scroll-to-top when quotes list is exhausted |
-| `packages/ui/MotionDiv.tsx` | Client | Framer Motion wrapper for entrance animations |
-| `packages/ui/utils/animate.tsx` | Util | Shared animation variant configs |
-| `packages/ui/skeletons/` | Server | Loading skeleton placeholders |
+| Module                                          | Type               | Responsibility                                                                                                |
+| ----------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `app/layout.tsx`                                | Server             | Root layout: metadata, PWA manifest, viewport; renders Header + main + Footer; defaults to `dark` on `<html>` |
+| `app/page.tsx`                                  | Server             | Home route — fetches and displays a random quote + author link                                                |
+| `app/[authorId]/page.tsx`                       | Server             | Author route — fetches first page of author quotes; sets title via `generateMetadata`                         |
+| `app/api/quotes/[author]/route.ts`              | Route Handler      | Pagination endpoint used by `LoadMore`; wraps `fetchAuthorQuotes`, sets cache headers                         |
+| `app/lib/data.ts`                               | Server-side module | API calls with `AbortController` timeouts and local `FALLBACK_QUOTES` on failure                              |
+| `app/loading.tsx`, `app/[authorId]/loading.tsx` | Server             | Suspense skeleton fallbacks during route data fetches                                                         |
+| `components/Header.tsx`                         | Client             | Nav bar; `useTransition`-driven random refresh (`router.push`/`router.refresh`)                               |
+| `components/ThemeToggle.tsx`                    | Client             | Dark/light toggle persisted to `localStorage`; toggles `.dark` on `<html>`                                    |
+| `packages/ui/Quote.tsx`                         | Server             | Quote card as a `<details>` disclosure (text → author/genre)                                                  |
+| `packages/ui/AuthorBtn.tsx`                     | Server             | Author link (anchor) with CSS hover affordance                                                                |
+| `packages/ui/RandomBtn.tsx`                     | Client             | Random button with loading spinner (`aria-busy`)                                                              |
+| `packages/ui/LoadMore.tsx`                      | Client             | Infinite scroll via Intersection Observer; fetches the pagination route                                       |
+| `packages/ui/MoveToTop.tsx`                     | Server             | "No more quotes" + scroll-to-top anchor when the list is exhausted                                            |
+| `packages/ui/skeletons/`                        | Server             | Loading skeleton placeholders                                                                                 |
+| `packages/ui/Footer.tsx`                        | Server             | Footer credit link                                                                                            |
 
 ## Data Flow Summary
 
-1. **Home page** — Server fetches one random quote → renders `Quote` + `AuthorBtn`
-2. **Author page** — Server fetches first 20 quotes → renders list + `LoadMore`
-3. **Infinite scroll** — `LoadMore` watches viewport; on entering view it fetches the next page (`offset += 20`) and appends quotes
-4. **Header click** — `router.refresh()` re-runs the server component, fetching a new random quote
-5. **All data fetches** use `unstable_noStore()` — responses are never cached
+1. **Home page** — Server calls `fetchRandomQuote()` → renders `Quote` + `AuthorBtn`.
+2. **Author page** — Server calls `fetchAuthorQuotes(author, 0)` (first 20) → renders the list + `LoadMore`.
+3. **Infinite scroll** — `LoadMore` (client) watches a sentinel via Intersection Observer; on entering view it fetches `GET /api/quotes/{author}?offset=N` (the route handler delegates to `fetchAuthorQuotes`), appends results, and advances the offset by 20. When a page comes back empty it renders `MoveToTop`.
+4. **Random refresh** — `Header`'s `RandomBtn` runs inside a `useTransition`: off the home route it `router.push("/")`, otherwise `router.refresh()` re-runs the home server component for a new quote.
+5. **Theme** — `ThemeToggle` reads/writes `localStorage["quoto-theme"]` and toggles the `dark` class on `<html>`.
+
+## Caching & Resilience
+
+- **Random quote** uses `cache: "no-store"` — always fresh, never cached.
+- **Author quotes** use `next: { revalidate: 300 }`; the API route additionally sets `Cache-Control: public, s-maxage=300, stale-while-revalidate=86400`.
+- **Timeouts** — requests are aborted via `AbortController` (random: 120 ms, author: 650 ms). On any error or timeout, `data.ts` returns local `FALLBACK_QUOTES` so the UI never hard-fails.
+
+## Animations
+
+Entrance and disclosure animations are **pure CSS** (Tailwind transitions plus the `quote-details-in` keyframe in `packages/ui/styles.css`) and respect `prefers-reduced-motion`. There is no `framer-motion` dependency.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20-alpine AS base
+FROM node:24-alpine AS base
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
 
@@ -18,7 +18,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build --workspace web
 
-FROM node:20-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To build all apps and packages, run the following command:
 
 ```
 cd quoto
-npm build
+npm run build
 ```
 
 ### Develop
@@ -26,8 +26,22 @@ To develop all apps and packages, run the following command:
 
 ```
 cd quoto
-npm dev
+npm run dev
 ```
+
+### Test
+
+To lint, typecheck, and run the unit and end-to-end tests:
+
+```
+cd quoto
+npm run lint
+npm run typecheck
+npm test
+npm run test:e2e
+```
+
+These same checks run in CI on every pull request (see `.github/workflows/ci.yml`).
 
 ### Docker
 

--- a/apps/web/app/[authorId]/loading.tsx
+++ b/apps/web/app/[authorId]/loading.tsx
@@ -1,18 +1,18 @@
 import QuoteSkeleton from "@repo/ui/src/skeletons/QuoteSkeleton";
 
 const loading = () => {
-	return (
-		<>
-			<div className="h-8 ml-12 lg:ml-16 lg:h-10 mt-8 lg:mt-16 bg-gray-300 animate-pulse w-2/6 rounded"></div>
+  return (
+    <>
+      <div className="h-8 ml-12 lg:ml-16 lg:h-10 mt-8 lg:mt-16 bg-gray-300 animate-pulse w-2/6 rounded"></div>
 
-			<div className="flex flex-col gap-12 mt-8 lg:gap-20 lg:mt-20 mb-20 w-full">
-				<QuoteSkeleton />
-				<QuoteSkeleton />
-				<QuoteSkeleton />
-				<QuoteSkeleton />
-				<QuoteSkeleton />
-			</div>
-		</>
-	);
+      <div className="flex flex-col gap-12 mt-8 lg:gap-20 lg:mt-20 mb-20 w-full">
+        <QuoteSkeleton />
+        <QuoteSkeleton />
+        <QuoteSkeleton />
+        <QuoteSkeleton />
+        <QuoteSkeleton />
+      </div>
+    </>
+  );
 };
 export default loading;

--- a/apps/web/app/api/quotes/[author]/route.ts
+++ b/apps/web/app/api/quotes/[author]/route.ts
@@ -4,20 +4,20 @@ import { fetchAuthorQuotes } from "../../../lib/data";
 export const revalidate = 300;
 
 export async function GET(
-	request: NextRequest,
-	{ params }: { params: { author: string } }
+  request: NextRequest,
+  { params }: { params: { author: string } },
 ) {
-	const offsetParam = request.nextUrl.searchParams.get("offset");
-	const offset = Number(offsetParam);
-	const safeOffset = Number.isFinite(offset) && offset > 0 ? offset : 0;
-	const quotes = await fetchAuthorQuotes(
-		decodeURIComponent(params.author),
-		safeOffset
-	);
+  const offsetParam = request.nextUrl.searchParams.get("offset");
+  const offset = Number(offsetParam);
+  const safeOffset = Number.isFinite(offset) && offset > 0 ? offset : 0;
+  const quotes = await fetchAuthorQuotes(
+    decodeURIComponent(params.author),
+    safeOffset,
+  );
 
-	return NextResponse.json(quotes, {
-		headers: {
-			"Cache-Control": "public, s-maxage=300, stale-while-revalidate=86400",
-		},
-	});
+  return NextResponse.json(quotes, {
+    headers: {
+      "Cache-Control": "public, s-maxage=300, stale-while-revalidate=86400",
+    },
+  });
 }

--- a/apps/web/app/lib/data.test.ts
+++ b/apps/web/app/lib/data.test.ts
@@ -1,9 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("next/cache", () => ({
-  unstable_noStore: vi.fn(),
-}));
-
 import { fetchAuthorQuotes, fetchRandomQuote } from "./data";
 
 describe("quote data fallbacks", () => {

--- a/apps/web/app/lib/data.ts
+++ b/apps/web/app/lib/data.ts
@@ -1,172 +1,172 @@
 export type QuoteProp = {
-	id?: string;
-	text: string;
-	author: string;
-	genre: string;
+  id?: string;
+  text: string;
+  author: string;
+  genre: string;
 };
 
 const FALLBACK_QUOTES: [QuoteProp, ...QuoteProp[]] = [
-	{
-		id: "f1",
-		text: "The only way to do great work is to love what you do.",
-		author: "Steve Jobs",
-		genre: "inspirational",
-	},
-	{
-		id: "f2",
-		text: "In the middle of every difficulty lies opportunity.",
-		author: "Albert Einstein",
-		genre: "inspirational",
-	},
-	{
-		id: "f3",
-		text: "It does not matter how slowly you go as long as you do not stop.",
-		author: "Confucius",
-		genre: "perseverance",
-	},
-	{
-		id: "f4",
-		text: "Life is what happens when you're busy making other plans.",
-		author: "John Lennon",
-		genre: "life",
-	},
-	{
-		id: "f5",
-		text: "The future belongs to those who believe in the beauty of their dreams.",
-		author: "Eleanor Roosevelt",
-		genre: "inspirational",
-	},
-	{
-		id: "f6",
-		text: "Spread love everywhere you go. Let no one ever come to you without leaving happier.",
-		author: "Mother Teresa",
-		genre: "love",
-	},
-	{
-		id: "f7",
-		text: "When you reach the end of your rope, tie a knot in it and hang on.",
-		author: "Franklin D. Roosevelt",
-		genre: "perseverance",
-	},
-	{
-		id: "f8",
-		text: "Always remember that you are absolutely unique. Just like everyone else.",
-		author: "Margaret Mead",
-		genre: "humor",
-	},
-	{
-		id: "f9",
-		text: "Do not go where the path may lead, go instead where there is no path and leave a trail.",
-		author: "Ralph Waldo Emerson",
-		genre: "inspirational",
-	},
-	{
-		id: "f10",
-		text: "You will face many defeats in life, but never let yourself be defeated.",
-		author: "Maya Angelou",
-		genre: "perseverance",
-	},
-	{
-		id: "f11",
-		text: "The greatest glory in living lies not in never falling, but in rising every time we fall.",
-		author: "Nelson Mandela",
-		genre: "inspirational",
-	},
-	{
-		id: "f12",
-		text: "In the end, it's not the years in your life that count. It's the life in your years.",
-		author: "Abraham Lincoln",
-		genre: "life",
-	},
-	{
-		id: "f13",
-		text: "Never let the fear of striking out keep you from playing the game.",
-		author: "Babe Ruth",
-		genre: "sports",
-	},
-	{
-		id: "f14",
-		text: "Life is either a daring adventure or nothing at all.",
-		author: "Helen Keller",
-		genre: "life",
-	},
-	{
-		id: "f15",
-		text: "Many of life's failures are people who did not realize how close they were to success when they gave up.",
-		author: "Thomas A. Edison",
-		genre: "perseverance",
-	},
-	{
-		id: "f16",
-		text: "You have brains in your head. You have feet in your shoes. You can steer yourself any direction you choose.",
-		author: "Dr. Seuss",
-		genre: "inspirational",
-	},
-	{
-		id: "f17",
-		text: "If life were predictable it would cease to be life and be without flavor.",
-		author: "Eleanor Roosevelt",
-		genre: "life",
-	},
-	{
-		id: "f18",
-		text: "If you look at what you have in life, you'll always have more.",
-		author: "Oprah Winfrey",
-		genre: "gratitude",
-	},
-	{
-		id: "f19",
-		text: "If you want to live a happy life, tie it to a goal, not to people or things.",
-		author: "Albert Einstein",
-		genre: "happiness",
-	},
-	{
-		id: "f20",
-		text: "Never let the fear of striking out keep you from playing the game.",
-		author: "Babe Ruth",
-		genre: "sports",
-	},
-	{
-		id: "f21",
-		text: "Money and success don't change people; they merely amplify what is already there.",
-		author: "Will Smith",
-		genre: "success",
-	},
-	{
-		id: "f22",
-		text: "Your time is limited, so don't waste it living someone else's life.",
-		author: "Steve Jobs",
-		genre: "life",
-	},
-	{
-		id: "f23",
-		text: "Not how long, but how well you have lived is the main thing.",
-		author: "Seneca",
-		genre: "philosophy",
-	},
-	{
-		id: "f24",
-		text: "If you're not stubborn, you'll give up on experiments too soon.",
-		author: "Jeff Bezos",
-		genre: "perseverance",
-	},
-	{
-		id: "f25",
-		text: "We must accept finite disappointment, but we must never lose infinite hope.",
-		author: "Martin Luther King Jr.",
-		genre: "hope",
-	},
+  {
+    id: "f1",
+    text: "The only way to do great work is to love what you do.",
+    author: "Steve Jobs",
+    genre: "inspirational",
+  },
+  {
+    id: "f2",
+    text: "In the middle of every difficulty lies opportunity.",
+    author: "Albert Einstein",
+    genre: "inspirational",
+  },
+  {
+    id: "f3",
+    text: "It does not matter how slowly you go as long as you do not stop.",
+    author: "Confucius",
+    genre: "perseverance",
+  },
+  {
+    id: "f4",
+    text: "Life is what happens when you're busy making other plans.",
+    author: "John Lennon",
+    genre: "life",
+  },
+  {
+    id: "f5",
+    text: "The future belongs to those who believe in the beauty of their dreams.",
+    author: "Eleanor Roosevelt",
+    genre: "inspirational",
+  },
+  {
+    id: "f6",
+    text: "Spread love everywhere you go. Let no one ever come to you without leaving happier.",
+    author: "Mother Teresa",
+    genre: "love",
+  },
+  {
+    id: "f7",
+    text: "When you reach the end of your rope, tie a knot in it and hang on.",
+    author: "Franklin D. Roosevelt",
+    genre: "perseverance",
+  },
+  {
+    id: "f8",
+    text: "Always remember that you are absolutely unique. Just like everyone else.",
+    author: "Margaret Mead",
+    genre: "humor",
+  },
+  {
+    id: "f9",
+    text: "Do not go where the path may lead, go instead where there is no path and leave a trail.",
+    author: "Ralph Waldo Emerson",
+    genre: "inspirational",
+  },
+  {
+    id: "f10",
+    text: "You will face many defeats in life, but never let yourself be defeated.",
+    author: "Maya Angelou",
+    genre: "perseverance",
+  },
+  {
+    id: "f11",
+    text: "The greatest glory in living lies not in never falling, but in rising every time we fall.",
+    author: "Nelson Mandela",
+    genre: "inspirational",
+  },
+  {
+    id: "f12",
+    text: "In the end, it's not the years in your life that count. It's the life in your years.",
+    author: "Abraham Lincoln",
+    genre: "life",
+  },
+  {
+    id: "f13",
+    text: "Never let the fear of striking out keep you from playing the game.",
+    author: "Babe Ruth",
+    genre: "sports",
+  },
+  {
+    id: "f14",
+    text: "Life is either a daring adventure or nothing at all.",
+    author: "Helen Keller",
+    genre: "life",
+  },
+  {
+    id: "f15",
+    text: "Many of life's failures are people who did not realize how close they were to success when they gave up.",
+    author: "Thomas A. Edison",
+    genre: "perseverance",
+  },
+  {
+    id: "f16",
+    text: "You have brains in your head. You have feet in your shoes. You can steer yourself any direction you choose.",
+    author: "Dr. Seuss",
+    genre: "inspirational",
+  },
+  {
+    id: "f17",
+    text: "If life were predictable it would cease to be life and be without flavor.",
+    author: "Eleanor Roosevelt",
+    genre: "life",
+  },
+  {
+    id: "f18",
+    text: "If you look at what you have in life, you'll always have more.",
+    author: "Oprah Winfrey",
+    genre: "gratitude",
+  },
+  {
+    id: "f19",
+    text: "If you want to live a happy life, tie it to a goal, not to people or things.",
+    author: "Albert Einstein",
+    genre: "happiness",
+  },
+  {
+    id: "f20",
+    text: "Never let the fear of striking out keep you from playing the game.",
+    author: "Babe Ruth",
+    genre: "sports",
+  },
+  {
+    id: "f21",
+    text: "Money and success don't change people; they merely amplify what is already there.",
+    author: "Will Smith",
+    genre: "success",
+  },
+  {
+    id: "f22",
+    text: "Your time is limited, so don't waste it living someone else's life.",
+    author: "Steve Jobs",
+    genre: "life",
+  },
+  {
+    id: "f23",
+    text: "Not how long, but how well you have lived is the main thing.",
+    author: "Seneca",
+    genre: "philosophy",
+  },
+  {
+    id: "f24",
+    text: "If you're not stubborn, you'll give up on experiments too soon.",
+    author: "Jeff Bezos",
+    genre: "perseverance",
+  },
+  {
+    id: "f25",
+    text: "We must accept finite disappointment, but we must never lose infinite hope.",
+    author: "Martin Luther King Jr.",
+    genre: "hope",
+  },
 ];
 
 type AuthorQuotesResponse = {
-	pagination: {
-		total: number;
-		limit: number;
-		offset: number;
-	};
-	data: {
-		quotes: QuoteProp[];
-	};
+  pagination: {
+    total: number;
+    limit: number;
+    offset: number;
+  };
+  data: {
+    quotes: QuoteProp[];
+  };
 };
 
 const API_BASE_URL = "https://api-quoto.onrender.com/v1/quote";
@@ -175,70 +175,75 @@ const RANDOM_TIMEOUT_MS = 120;
 const AUTHOR_TIMEOUT_MS = 650;
 
 const getRandomFallbackQuote = (): QuoteProp =>
-	FALLBACK_QUOTES[Math.floor(Math.random() * FALLBACK_QUOTES.length)] ??
-	FALLBACK_QUOTES[0]!;
+  FALLBACK_QUOTES[Math.floor(Math.random() * FALLBACK_QUOTES.length)] ??
+  FALLBACK_QUOTES[0]!;
 
 const fetchWithTimeout = async (
-	input: string,
-	init?: RequestInit & { next?: { revalidate?: number } },
-	timeoutMs = AUTHOR_TIMEOUT_MS
+  input: string,
+  init?: RequestInit & { next?: { revalidate?: number } },
+  timeoutMs = AUTHOR_TIMEOUT_MS,
 ) => {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-	try {
-		return await fetch(input, {
-			...init,
-			signal: controller.signal,
-		});
-	} finally {
-		clearTimeout(timeout);
-	}
+  try {
+    return await fetch(input, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
 };
 
-const getFallbackForAuthor = (author: string, offset: number): AuthorQuotesResponse => {
-	const authorQuotes = FALLBACK_QUOTES.filter(
-		(q) => q.author.toLowerCase() === author.toLowerCase()
-	);
-	const pool = authorQuotes.length > 0 ? authorQuotes : FALLBACK_QUOTES;
-	const page = pool.slice(offset, offset + PAGE_SIZE);
-	return {
-		pagination: { total: pool.length, limit: PAGE_SIZE, offset },
-		data: { quotes: page },
-	};
+const getFallbackForAuthor = (
+  author: string,
+  offset: number,
+): AuthorQuotesResponse => {
+  const authorQuotes = FALLBACK_QUOTES.filter(
+    (q) => q.author.toLowerCase() === author.toLowerCase(),
+  );
+  const pool = authorQuotes.length > 0 ? authorQuotes : FALLBACK_QUOTES;
+  const page = pool.slice(offset, offset + PAGE_SIZE);
+  return {
+    pagination: { total: pool.length, limit: PAGE_SIZE, offset },
+    data: { quotes: page },
+  };
 };
 
 export const fetchRandomQuote = async (): Promise<QuoteProp> => {
-	try {
-		const response = await fetchWithTimeout(
-			`${API_BASE_URL}/random`,
-			{
-				cache: "no-store",
-			},
-			RANDOM_TIMEOUT_MS
-		);
-		if (!response.ok) throw new Error(`API responded with ${response.status}`);
-		return await response.json();
-	} catch {
-		return getRandomFallbackQuote();
-	}
+  try {
+    const response = await fetchWithTimeout(
+      `${API_BASE_URL}/random`,
+      {
+        cache: "no-store",
+      },
+      RANDOM_TIMEOUT_MS,
+    );
+    if (!response.ok) throw new Error(`API responded with ${response.status}`);
+    return await response.json();
+  } catch {
+    return getRandomFallbackQuote();
+  }
 };
 
 export const fetchAuthorQuotes = async (
-	author: string,
-	offset: number
+  author: string,
+  offset: number,
 ): Promise<AuthorQuotesResponse> => {
-	try {
-		const response = await fetchWithTimeout(
-			`${API_BASE_URL}/${encodeURIComponent(author)}?limit=${PAGE_SIZE}&offset=${offset}`,
-			{
-				next: { revalidate: 300 },
-			},
-			AUTHOR_TIMEOUT_MS
-		);
-		if (!response.ok) throw new Error(`API responded with ${response.status}`);
-		return await response.json();
-	} catch {
-		return getFallbackForAuthor(author, offset);
-	}
+  try {
+    const response = await fetchWithTimeout(
+      `${API_BASE_URL}/${encodeURIComponent(
+        author,
+      )}?limit=${PAGE_SIZE}&offset=${offset}`,
+      {
+        next: { revalidate: 300 },
+      },
+      AUTHOR_TIMEOUT_MS,
+    );
+    if (!response.ok) throw new Error(`API responded with ${response.status}`);
+    return await response.json();
+  } catch {
+    return getFallbackForAuthor(author, offset);
+  }
 };

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -2,11 +2,11 @@ import AuthorBtnSkeleton from "@repo/ui/src/skeletons/AuthorBtnSkeleton";
 import QuoteSkeleton from "@repo/ui/src/skeletons/QuoteSkeleton";
 
 const Loading = () => {
-	return (
-		<div className="mt-16 lg:mt-24 ">
-			<QuoteSkeleton />
-			<AuthorBtnSkeleton />
-		</div>
-	);
+  return (
+    <div className="mt-16 lg:mt-24 ">
+      <QuoteSkeleton />
+      <AuthorBtnSkeleton />
+    </div>
+  );
 };
 export default Loading;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings 0",
+    "typecheck": "tsc --noEmit",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/apps/web/types/testing-library.d.ts
+++ b/apps/web/types/testing-library.d.ts
@@ -1,0 +1,5 @@
+// Loads @testing-library/jest-dom's custom matcher types into the Vitest
+// `expect` so `tsc` recognises matchers (toBeVisible, toHaveClass, ...) used
+// in test files. The matchers themselves are registered at runtime by the
+// root vitest.setup.ts, which lives outside this project's tsconfig include.
+import "@testing-library/jest-dom/vitest";

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
+    "typecheck": "turbo typecheck",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "npm run test:e2e --workspace web",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,6 +6,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "lint": "eslint . --max-warnings 0",
+    "typecheck": "tsc --noEmit",
     "generate:component": "turbo gen react-component"
   },
   "devDependencies": {

--- a/packages/ui/src/MoveToTop.tsx
+++ b/packages/ui/src/MoveToTop.tsx
@@ -1,26 +1,28 @@
 const MoveToTop = () => {
-	return (
-		<div className="mb-20 flex w-fit items-center gap-4 text-base sm:text-lg">
-			<span className="rounded-md bg-[#F7DF94]/40 px-4 py-3 text-[#333333] dark:text-[#F2F2F2]">
-				No more quotes to show
-			</span>
-			<a
-				href="#top"
-				className="rounded-full bg-[#F7DF94]/40 p-4 text-[#333333] transition hover:bg-[#F7DF94]/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#F7DF94] dark:text-[#F2F2F2]"
-				aria-label="Move to top">
-				<svg
-					aria-hidden="true"
-					className="h-5 w-5"
-					fill="none"
-					viewBox="0 0 24 24"
-					stroke="currentColor"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-					strokeWidth="2">
-					<path d="m18 15-6-6-6 6" />
-				</svg>
-			</a>
-		</div>
-	);
+  return (
+    <div className="mb-20 flex w-fit items-center gap-4 text-base sm:text-lg">
+      <span className="rounded-md bg-[#F7DF94]/40 px-4 py-3 text-[#333333] dark:text-[#F2F2F2]">
+        No more quotes to show
+      </span>
+      <a
+        href="#top"
+        className="rounded-full bg-[#F7DF94]/40 p-4 text-[#333333] transition hover:bg-[#F7DF94]/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#F7DF94] dark:text-[#F2F2F2]"
+        aria-label="Move to top"
+      >
+        <svg
+          aria-hidden="true"
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+        >
+          <path d="m18 15-6-6-6 6" />
+        </svg>
+      </a>
+    </div>
+  );
 };
 export default MoveToTop;

--- a/packages/ui/src/skeletons/AuthorBtnSkeleton.tsx
+++ b/packages/ui/src/skeletons/AuthorBtnSkeleton.tsx
@@ -1,13 +1,13 @@
 const AuthorBtnSkeleton = () => {
-	return (
-		<div className="pl-6 mt-8 lg:mt-12">
-			<button className="flex items-center justify-between w-full p-6 lg:p-10 bg-[#333333]">
-				<div className="flex flex-col items-start w-full gap-2">
-					<div className="text-xl capitalize  bg-gray-200 rounded h-4 w-2/5 animate-pulse"></div>
-					<div className="text-xl capitalize  bg-gray-100 rounded h-3 w-1/5 animate-pulse"></div>
-				</div>
-			</button>
-		</div>
-	);
+  return (
+    <div className="pl-6 mt-8 lg:mt-12">
+      <button className="flex items-center justify-between w-full p-6 lg:p-10 bg-[#333333]">
+        <div className="flex flex-col items-start w-full gap-2">
+          <div className="text-xl capitalize  bg-gray-200 rounded h-4 w-2/5 animate-pulse"></div>
+          <div className="text-xl capitalize  bg-gray-100 rounded h-3 w-1/5 animate-pulse"></div>
+        </div>
+      </button>
+    </div>
+  );
 };
 export default AuthorBtnSkeleton;

--- a/packages/ui/src/skeletons/QuoteSkeleton.tsx
+++ b/packages/ui/src/skeletons/QuoteSkeleton.tsx
@@ -1,12 +1,12 @@
 const QuoteSkeleton = () => {
-	return (
-		<div className="text-xl lg:text-4xl w-full lg:max-w-3xl border-l-[#F7DF94] pl-10 border-l-8 mx-auto  flex flex-col gap-1">
-			<span>"</span>
-			<p className="animate-pulse w-full h-4 lg:h-10 bg-slate-300 rounded-md"></p>
-			<p className="animate-pulse w-full h-4 lg:h-10 bg-slate-300 rounded-md"></p>
-			<p className="animate-pulse w-1/2  h-4 lg:h-10 bg-slate-300 rounded-md"></p>
-			<span>"</span>
-		</div>
-	);
+  return (
+    <div className="text-xl lg:text-4xl w-full lg:max-w-3xl border-l-[#F7DF94] pl-10 border-l-8 mx-auto  flex flex-col gap-1">
+      <span>"</span>
+      <p className="animate-pulse w-full h-4 lg:h-10 bg-slate-300 rounded-md"></p>
+      <p className="animate-pulse w-full h-4 lg:h-10 bg-slate-300 rounded-md"></p>
+      <p className="animate-pulse w-1/2  h-4 lg:h-10 bg-slate-300 rounded-md"></p>
+      <span>"</span>
+    </div>
+  );
 };
 export default QuoteSkeleton;

--- a/packages/ui/src/testing-library.d.ts
+++ b/packages/ui/src/testing-library.d.ts
@@ -1,0 +1,5 @@
+// Loads @testing-library/jest-dom's custom matcher types into the Vitest
+// `expect` so `tsc` recognises matchers (toHaveAttribute, toBeInTheDocument,
+// ...) used in test files. The matchers themselves are registered at runtime
+// by the root vitest.setup.ts, which lives outside this project's tsconfig.
+import "@testing-library/jest-dom/vitest";

--- a/packages/ui/src/utils/animate.tsx
+++ b/packages/ui/src/utils/animate.tsx
@@ -1,19 +1,19 @@
 export const container = {
-	hidden: { opacity: 1, scale: 0 },
-	visible: {
-		opacity: 1,
-		scale: 1,
-		transition: {
-			delayChildren: 0.3,
-			staggerChildren: 0.2,
-		},
-	},
+  hidden: { opacity: 1, scale: 0 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: {
+      delayChildren: 0.3,
+      staggerChildren: 0.2,
+    },
+  },
 };
 
 export const item = {
-	hidden: { x: -20, opacity: 0 },
-	visible: {
-		x: 0,
-		opacity: 1,
-	},
+  hidden: { x: -20, opacity: 0 },
+  visible: {
+    x: 0,
+    opacity: 1,
+  },
 };

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,9 @@
     "lint": {
       "dependsOn": ["^lint"]
     },
+    "typecheck": {
+      "dependsOn": ["^typecheck"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Overview

A repo-health pass: adds CI, makes a standalone type-check pass, refreshes drifted documentation, and normalizes formatting. No runtime/behavior changes to the app.

## What changed & why

### CI (new)
- `.github/workflows/ci.yml` — on every push to `main` and PR, runs two jobs on Node 24:
  - **verify**: `lint` → `typecheck` → unit tests → `build`
  - **e2e**: installs Playwright chromium, runs the e2e suite, uploads the report artifact
- The repo already had unit + e2e tests but nothing enforced them.

### Typecheck fix (+ scripts)
- `tsc --noEmit` previously **failed** on the test files (`toBeVisible`, `toHaveClass`, … "does not exist on type Assertion"). Root cause: the `@testing-library/jest-dom` matcher types were only registered at runtime in the root `vitest.setup.ts`, which lives outside each project's `tsconfig` include.
- Added a tiny declaration in each TS project (`apps/web/types/testing-library.d.ts`, `packages/ui/src/testing-library.d.ts`) that loads the augmentation.
- Added a `typecheck` script to `web` and `@repo/ui`, a `typecheck` turbo task, and a root `npm run typecheck`. `tsc` now passes cleanly across the monorepo.

### Dockerfile
- Bumped both stages `node:20-alpine` → `node:24-alpine` to match `engines.node` (`24.x`).
- ⚠️ Updated but **not built/tested locally** (no Docker available in this environment).

### Docs
- Rewrote `CODE_FLOW.md` to match the current architecture: CSS animations (no framer-motion), the `/api/quotes/[author]` route handler, `ThemeToggle`, and the real caching/timeout/fallback behavior. The previous version described a removed framer-motion/`unstable_noStore` design.
- Removed the vestigial `next/cache` `unstable_noStore` mock from `data.test.ts` (`data.ts` no longer imports it).
- `README.md`: fixed `npm build`/`npm dev` → `npm run build`/`npm run dev`; added a Test section.

### Formatting
- Added `.prettierignore` so `npm run format` no longer rewrites `.next/` build output (Prettier only auto-ignores `node_modules`).
- Ran `npm run format`, normalizing the tab/space mix. This accounts for most of the diff's line count (e.g. `data.ts` is whitespace-only).

## Verification

All green locally: `lint` ✅ · `typecheck` ✅ · unit tests **5/5** ✅ · `build` ✅ · e2e **1/1** ✅ (also run with `CI=1`).

## Reviewer notes

- Most of the line-count is mechanical Prettier reformatting (tabs → spaces); the substantive changes are the new CI workflow, the typecheck declarations + scripts, `CODE_FLOW.md`, and the Dockerfile Node bump.
- The Dockerfile change is unverified (no Docker locally).
- Deliberately **not** changed: the aggressive fetch timeouts (120 ms random / 650 ms author) are a behavioral trade-off, not a bug.
- Follow-up (out of scope): `packages/ui/src/utils/animate.tsx` is dead code (framer-motion variants nothing imports; framer-motion is no longer a dependency) and can be removed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)